### PR TITLE
Fixed upstart script env

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ Installs [kafka](https://kafka.apache.org/)
 - monasca_log_level - Log level to be used for Kafka logs. Defaults to WARN
 - monasca_wait_for_period - The time in seconds for how long to wait for Kafka's port to be available after starting it. Default is 30 seconds.
 - run_mode - One of Deploy, Stop, Install, Start, or Use. The default is Deploy which will do Install, Configure, then Start.
+- set_java_home - Set `JAVA_HOME` env var for systemd/upstart. Default: `False`
 - java_home - `JAVA_HOME` env var. Default: `/usr/local/java`
 
 ## License

--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ Installs [kafka](https://kafka.apache.org/)
 - monasca_log_level - Log level to be used for Kafka logs. Defaults to WARN
 - monasca_wait_for_period - The time in seconds for how long to wait for Kafka's port to be available after starting it. Default is 30 seconds.
 - run_mode - One of Deploy, Stop, Install, Start, or Use. The default is Deploy which will do Install, Configure, then Start.
+- java_home - `JAVA_HOME` env var. Default: `/usr/local/java`
 
 ## License
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -5,6 +5,7 @@ kafka_version_prefix: 2.11
 kafka_version: 0.10.2.1
 run_mode: Deploy
 skip_install: False
+java_home: /usr/local/java
 
 kafka_num_network_threads: 3
 kafka_num_io_threads: 8

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -5,6 +5,7 @@ kafka_version_prefix: 2.11
 kafka_version: 0.10.2.1
 run_mode: Deploy
 skip_install: False
+set_java_home: False
 java_home: /usr/local/java
 
 kafka_num_network_threads: 3

--- a/templates/kafka.conf.j2
+++ b/templates/kafka.conf.j2
@@ -15,4 +15,4 @@ pre-start script
 end script
 
 # Rather than using setuid/setgid sudo is used because the pre-start task must run as root
-exec sudo -Hu kafka -g kafka JAVA_HOME="/usr/local/java" KAFKA_HEAP_OPTS="{{ kafka_heap_opts }}" /opt/kafka/bin/kafka-server-start.sh /etc/kafka/server.properties
+exec sudo -Hu kafka -g kafka JAVA_HOME="{{ java_home }}" KAFKA_HEAP_OPTS="{{ kafka_heap_opts }}" /opt/kafka/bin/kafka-server-start.sh /etc/kafka/server.properties

--- a/templates/kafka.conf.j2
+++ b/templates/kafka.conf.j2
@@ -15,4 +15,4 @@ pre-start script
 end script
 
 # Rather than using setuid/setgid sudo is used because the pre-start task must run as root
-exec sudo -Hu kafka -g kafka KAFKA_HEAP_OPTS="{{ kafka_heap_opts }}" /opt/kafka/bin/kafka-server-start.sh /etc/kafka/server.properties
+exec sudo -Hu kafka -g kafka JAVA_HOME="/usr/local/java" KAFKA_HEAP_OPTS="{{ kafka_heap_opts }}" /opt/kafka/bin/kafka-server-start.sh /etc/kafka/server.properties

--- a/templates/kafka.conf.j2
+++ b/templates/kafka.conf.j2
@@ -15,4 +15,4 @@ pre-start script
 end script
 
 # Rather than using setuid/setgid sudo is used because the pre-start task must run as root
-exec sudo -Hu kafka -g kafka JAVA_HOME="{{ java_home }}" KAFKA_HEAP_OPTS="{{ kafka_heap_opts }}" /opt/kafka/bin/kafka-server-start.sh /etc/kafka/server.properties
+exec sudo -Hu kafka -g kafka {% if set_java_home %}JAVA_HOME="{{ java_home }}" {% endif %}KAFKA_HEAP_OPTS="{{ kafka_heap_opts }}" /opt/kafka/bin/kafka-server-start.sh /etc/kafka/server.properties

--- a/templates/kafka.service.j2
+++ b/templates/kafka.service.j2
@@ -9,6 +9,7 @@ Group=kafka
 LimitNOFILE=32768
 Restart=on-failure
 Environment="KAFKA_HEAP_OPTS={{ kafka_heap_opts }}"
+Environment="JAVA_HOME={{ java_home }}"
 ExecStart=/opt/kafka/bin/kafka-server-start.sh /etc/kafka/server.properties
 
 [Install]

--- a/templates/kafka.service.j2
+++ b/templates/kafka.service.j2
@@ -9,7 +9,9 @@ Group=kafka
 LimitNOFILE=32768
 Restart=on-failure
 Environment="KAFKA_HEAP_OPTS={{ kafka_heap_opts }}"
+{% if set_java_home %}
 Environment="JAVA_HOME={{ java_home }}"
+{% endif %}
 ExecStart=/opt/kafka/bin/kafka-server-start.sh /etc/kafka/server.properties
 
 [Install]


### PR DESCRIPTION
Hello!
On some Ubuntu 14.04 installations got following problem:

```
/opt/kafka/bin/kafka-run-class.sh: line 258: exec: java: not found
```

It was fixed by setting `JAVA_HOME` env var to upstart script.

That PR contains this fix.